### PR TITLE
Use cursor into Chain instead of index

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/Combinator.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/Combinator.scala
@@ -21,7 +21,7 @@ object Combinator {
   private class OkParser[Input, Output](a: Output) extends  Parser[Input, Output]{
     override def toString(): String = s"ok(${a.toString()})"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
@@ -29,18 +29,18 @@ object Combinator {
   }
 
   /** Parser that consumes no data and fails with the specified error message. */
-  def err[Input, Output](what: String): Parser[Input, Output] = 
+  def err[Input, Output](what: String): Parser[Input, Output] =
     new ErrParser[Input, Output](what)
   private class ErrParser[Input, Output](what: String) extends Parser[Input, Output]{
     override def toString(): String = s"err($what)"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
       Eval.defer(kf(st0, Nil, what))
   }
-  
+
   /** Construct the given parser lazily; useful when defining recursive parsers. */
   def delay[Input, Output](p: => Parser[Input, Output]): Parser[Input, Output] =
     new DelayParser[Input, Output](p)
@@ -48,27 +48,15 @@ object Combinator {
   private class DelayParser[Input, Output](p: => Parser[Input,Output]) extends Parser[Input, Output]{
     override def toString(): String = p.toString
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
       p.apply(st0, kf, ks)
   }
 
-  
-  /////
 
-  def advance[Input](n: Int): Parser[Input, Unit] = 
-    new AdvanceParser[Input, Unit](n)
-  private class AdvanceParser[Input, Output](n: Int) extends Parser[Input, Unit]{
-    override def toString(): String = s"advance($n)"
-    def apply[R](
-      st0: State[Input], 
-      kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
-      ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
-    ): Eval[Internal.Result[Input, R]] =
-      ks(st0.copy(pos = Parser.Pos(st0.pos.value + n)), ())
-  }
+  /////
 
   private def prompt[Input, Output](
     st0: State[Input],
@@ -76,8 +64,8 @@ object Combinator {
     ks: State[Input] => Eval[Internal.Result[Input, Output]]
   ): Parser.Internal.Result[Input, Output] =
     Parser.Internal.Partial[Input, Output](s =>
-    if (s.isEmpty) Eval.defer(kf(st0.copy(complete =IsComplete.Complete)))
-    else Eval.defer(ks(st0.copy(input = st0.input <+> s, complete = IsComplete.NotComplete)))
+    if (s.isEmpty) Eval.defer(kf(st0.copy(complete = IsComplete.Complete)))
+    else Eval.defer(ks(State(input = st0.input <+> s, cursor = st0.cursor <+> s, complete = IsComplete.NotComplete)))
   )
 
   def demandInput[Input]: Parser[Input, Unit] = new DemandInputParser[Input]
@@ -85,7 +73,7 @@ object Combinator {
   private class DemandInputParser[Input] extends Parser[Input, Unit]{
     override def toString = "demandInput"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
@@ -98,47 +86,16 @@ object Combinator {
       )
   }
 
-  def ensureSuspended[Input](n: Int): Parser[Input, Chain[Input]] =
-    new EnsureSuspendedParser[Input](n)
-  private class EnsureSuspendedParser[Input](n: Int) extends Parser[Input, Chain[Input]]{
-    override def toString(): String = s"ensureSuspended($n)"
-    def apply[R](
-      st0: Parser.State[Input],
-      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
-      ks: (Parser.State[Input], Chain[Input]) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + n)
-        // Can Do Better - Chain Methods Inadequate
-        Eval.defer(ks(st0, Chain.fromSeq(st0.input.toList.drop(st0.pos.value).take(n))))
-      else 
-        Eval.defer(ensureSuspended(n)(st0, kf, ks))
-  }
-
-  def ensure[Input](n: Int): Parser[Input, Chain[Input]] =
-    new EnsureParser[Input](n)
-  private class EnsureParser[Input](n: Int) extends Parser[Input, Chain[Input]]{
-    override def toString(): String = s"ensure($n)"
-    def apply[R](
-      st0: Parser.State[Input],
-      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
-      ks: (Parser.State[Input], Chain[Input]) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + n)
-        Eval.defer(ks(st0, Chain.fromSeq(st0.input.toList.drop(st0.pos.value).take(n))))
-      else
-        Eval.defer(ensureSuspended(n)(st0, kf, ks))
-  }
-
   def wantInput[Input]: Parser[Input, Boolean] =
-    new WantInputParser[Input] 
+    new WantInputParser[Input]
   private class WantInputParser[Input] extends  Parser[Input, Boolean]{
     override def toString = "wantInput"
     def apply[R](
       st0: Parser.State[Input],
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], Boolean) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + 1) Eval.defer(ks(st0, true))
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      if (st0.cursor.nonEmpty) Eval.defer(ks(st0, true))
       else if (st0.complete.bool) Eval.defer(ks(st0, false))
       else Eval.now(prompt(st0, a => ks(a, false), a => ks(a, true)))
   }
@@ -146,41 +103,41 @@ object Combinator {
   /////
 
   /** Parser that produces the remaining input (but does not consume it). */
-  def get[Input]: Parser[Input, Chain[Input]] = 
+  def get[Input]: Parser[Input, Chain[Input]] =
     new GetParser[Input]
   private class GetParser[Input] extends Parser[Input, Chain[Input]]{
     override def toString = "get"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Chain[Input]) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, Parser.chainDrop(st0.input, st0.pos.value)))
+      Eval.defer(ks(st0, st0.cursor))
   }
 
   /* Parser that produces the current offset in the input. */
-  def pos[Input]: Parser[Input, Int] = 
+  def cursor[Input]: Parser[Input, Chain[Input]] =
     new PosParser[Input]
-  private class PosParser[Input] extends Parser[Input, Int]{
+  private class PosParser[Input] extends Parser[Input, Chain[Input]]{
     override def toString = "pos"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
-      ks: (State[Input], Int) => Eval[Internal.Result[Input, R]]
+      ks: (State[Input], Chain[Input]) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, st0.pos.value))
+      Eval.defer(ks(st0, st0.cursor))
   }
-  
+
   def endOfChunk[Input]: Parser[Input, Boolean] =
     new EndOfChunkParser[Input]
   private class EndOfChunkParser[Input] extends Parser[Input, Boolean]{
     override def toString = "endOfChunk"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Boolean) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, st0.pos.value == st0.input.length))
+      Eval.defer(ks(st0, st0.cursor.isEmpty))
   }
 
   def endOfInput[Input]: Parser[Input, Unit] =
@@ -188,11 +145,11 @@ object Combinator {
   private class EndOfInputParser[Input] extends Parser[Input, Unit]{
     override def toString = "endOfInput"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] = Eval.defer{
-      if (st0.pos.value >= st0.input.length) {
+      if (st0.cursor.isEmpty) {
         if (st0.complete.bool) ks(st0, ())
         else demandInput(
           st0,
@@ -205,8 +162,8 @@ object Combinator {
     }
   }
 
-  
-  def discardLeft[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] = 
+
+  def discardLeft[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] =
     new DiscardLeftParser[Input,A, B](m, b)
   private class DiscardLeftParser[Input, A, B](
     m: Parser[Input, A],
@@ -214,7 +171,7 @@ object Combinator {
   ) extends Parser[Input, B]{
     override def toString(): String = s"($m) ~> $b"
     def apply[R](
-        st0: State[Input], 
+        st0: State[Input],
         kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
         ks: (State[Input], B) => Eval[Internal.Result[Input, R]]
       ): Eval[Internal.Result[Input, R]] = {
@@ -224,20 +181,20 @@ object Combinator {
       }
   }
 
-  def discardRight[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]): Parser[Input, A] = 
+  def discardRight[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]): Parser[Input, A] =
     new DiscardRightParser(m, b)
   private class DiscardRightParser[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]) extends Parser[Input, A]{
     override def toString(): String = s"($m) <~ $b"
     def apply[R](
-        st0: State[Input], 
+        st0: State[Input],
         kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
         ks: (State[Input], A) => Eval[Internal.Result[Input, R]]
       ): Eval[Internal.Result[Input, R]] = {
         Eval.defer(
           m(
             st0,
-            kf, 
-            (st1: State[Input], a: A) => 
+            kf,
+            (st1: State[Input], a: A) =>
               b(st1, kf, (st2: State[Input], _: B) => ks(st2, a)
             )
           )
@@ -260,7 +217,7 @@ object Combinator {
   }
 
 
-  def orElse[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] = 
+  def orElse[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] =
     new OrElseParser(m, b)
   private class OrElseParser[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]) extends Parser[Input, B]{
     override def toString(): String = s"($m) | $b"
@@ -269,12 +226,12 @@ object Combinator {
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], B) => Eval[Parser.Internal.Result[Input,R]]
     ): Eval[Parser.Internal.Result[Input,R]] = Eval.defer(
-      m(st0, (st1: State[Input], _: List[String], _: String) => b(st1.copy(pos = st0.pos), kf, ks), ks)
+      m(st0, (st1: State[Input], _: List[String], _: String) => b(st1.copy(cursor = st0.cursor), kf, ks), ks)
     )
   }
 
 
-  def either[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, Either[A, B]] = 
+  def either[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, Either[A, B]] =
     new EitherParser[Input, A, B](m, b)
   private class EitherParser[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]) extends Parser[Input, Either[A, B]]{
     override def toString(): String = s"($m) || $b"
@@ -284,14 +241,42 @@ object Combinator {
       ks: (Parser.State[Input], Either[A, B]) => Eval[Parser.Internal.Result[Input,R]]
     ): Eval[Parser.Internal.Result[Input,R]] = Eval.defer(m(
       st0,
-      (st1: State[Input], _: List[String], _: String) => 
-        b(st1.copy(pos= st0.pos), kf, (st1: State[Input], b: B) => ks(st1, Right(b))),
+      (st1: State[Input], _: List[String], _: String) =>
+        b(st1.copy(cursor = st0.cursor), kf, (st1: State[Input], b: B) => ks(st1, Right(b))),
       (st1: State[Input], a: A) => ks(st1, Left(a))
     ))
   }
 
+  def elemSuspended[Input]: Parser[Input, Input] = new ElemSuspendedParser[Input]
+  private class ElemSuspendedParser[Input] extends Parser[Input, Input]{
+    override def toString(): String = "elemSuspended"
+    def apply[R](
+      st0: Parser.State[Input],
+      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
+      ks: (Parser.State[Input], Input) => Eval[Parser.Internal.Result[Input,R]]
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      st0.cursor.uncons match {
+        case Some((h, t)) => Eval.defer(ks(st0.copy(cursor = t), h))
+        case None => Eval.defer(discardLeft(demandInput[Input], elemSuspended[Input])(st0, kf, ks))
+      }
+  }
 
-  def named[Input, A](m: Parser[Input, A], s: => String): Parser[Input, A] = 
+  def elem[Input]: Parser[Input, Input] = new ElemParser[Input]
+  private class ElemParser[Input] extends Parser[Input, Input]{
+    override def toString(): String = "elem"
+    def apply[R](
+      st0: Parser.State[Input],
+      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
+      ks: (Parser.State[Input], Input) => Eval[Parser.Internal.Result[Input,R]]
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      st0.cursor.uncons match {
+        case Some((h, t)) => Eval.defer(ks(st0.copy(cursor = t), h))
+        case None => Eval.defer(elemSuspended(st0, kf, ks))
+      }
+  }
+
+
+  def named[Input, A](m: Parser[Input, A], s: => String): Parser[Input, A] =
     new NamedParser(m, s)
   private class NamedParser[Input, A](m: Parser[Input, A], s: => String) extends Parser[Input, A]{
     override def toString = s
@@ -299,7 +284,7 @@ object Combinator {
       st0: Parser.State[Input],
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], A) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
+    ): Eval[Parser.Internal.Result[Input,R]] =
       Eval.defer(m(st0, (st1: State[Input], stack: List[String], msg: String) => kf(st1, s:: stack, msg), ks))
   }
 
@@ -317,30 +302,29 @@ object Combinator {
   }
 
 
-  def modifyName[Input, A](m: Parser[Input, A], f: String => String): Parser[Input, A] = 
+  def modifyName[Input, A](m: Parser[Input, A], f: String => String): Parser[Input, A] =
     named(m, f(m.toString()))
 
   // Higher Level Combinators
   // Allowed to Use Implicits Based on the above
   import io.chrisdavenport.gatoparsec.implicits._
 
-  def take[Input](n: Int): Parser[Input, Chain[Input]] = 
-    ensure[Input](n).flatMap{c => 
-      advance(n) ~> ok(c)
-    }
+  // this could probably be better optimized
+  def take[Input](n: Int): Parser[Input, Chain[Input]] =
+    Traverse[Chain].sequence(Chain.fromSeq(List.fill(n)(elem[Input])))
 
-  def filter[Input, A](m: Parser[Input, A])(p: A => Boolean): Parser[Input, A] = 
-    m.flatMap{a => 
+  def filter[Input, A](m: Parser[Input, A])(p: A => Boolean): Parser[Input, A] =
+    m.flatMap{a =>
       if (p(a)) ok[Input](a) else err[Input, A]("filter")
     } named "filter(...)"
-  
-  def collect[Input, A, B](m: Parser[Input, A], f: PartialFunction[A, B]): Parser[Input, B] = 
+
+  def collect[Input, A, B](m: Parser[Input, A], f: PartialFunction[A, B]): Parser[Input, B] =
     filter(m)(f isDefinedAt _).map(f)
 
-  def cons[Input, A, B >: A](m: Parser[Input, A], n: => Parser[Input, List[B]]): Parser[Input, NonEmptyList[B]] = 
+  def cons[Input, A, B >: A](m: Parser[Input, A], n: => Parser[Input, List[B]]): Parser[Input, NonEmptyList[B]] =
     m.flatMap{x => n.map(xs => NonEmptyList(x, xs))}
 
-  def phrase[Input, A](p: Parser[Input, A]): Parser[Input, A] = 
+  def phrase[Input, A](p: Parser[Input, A]): Parser[Input, A] =
     p <~ endOfInput named ("phrase" + p.toString())
 
   def many[Input, A](p: => Parser[Input, A]): Parser[Input, List[A]] = {
@@ -351,7 +335,7 @@ object Combinator {
   def many1[Input, A](p: Parser[Input, A]): Parser[Input, NonEmptyList[A]] =
     cons(p, many(p))
 
-  def manyN[Input, A](n: Int, a: Parser[Input, A]): Parser[Input, List[A]] = 
+  def manyN[Input, A](n: Int, a: Parser[Input, A]): Parser[Input, List[A]] =
     (1.to(n)).foldRight(ok[Input](List[A]()))((_, p) => cons(a, p).map(_.toList))
       .named("ManyN(" + n.toString + ", " + a.toString + ")")
 
@@ -360,19 +344,19 @@ object Combinator {
     scan named "manyUntil(" + p.toString() + "," + q.toString() + ")"
   }
 
-  def skipMany[Input](p: Parser[Input, _]): Parser[Input, Unit] = 
+  def skipMany[Input](p: Parser[Input, _]): Parser[Input, Unit] =
     many(p).map(_ => ()) named s"skipMany($p)"
-  
-  def skipMany1[Input](p: Parser[Input, _]): Parser[Input, Unit] = 
+
+  def skipMany1[Input](p: Parser[Input, _]): Parser[Input, Unit] =
     many1(p).map(_ => ()) named s"skipMany1($p)"
-  
+
   def skipManyN[Input](n: Int, p: Parser[Input, _]): Parser[Input, Unit] =
     manyN(n, p).map(_ => ()) named s"skipManyN($n,$p)"
 
   def sepBy1[Input, A](p: Parser[Input, A], s: Parser[Input, _]): Parser[Input, NonEmptyList[A]] = {
-    lazy val scan : Parser[Input, NonEmptyList[A]] = 
+    lazy val scan : Parser[Input, NonEmptyList[A]] =
       cons(p, s ~> scan.map(_.toList) | ok(Nil))
-    
+
     scan named s"sepBy1($p,$s)"
   }
 
@@ -380,7 +364,7 @@ object Combinator {
     cons(p, ((s ~> sepBy1(p,s)).map(_.toList) | ok(List.empty[A]))).map(_.toList) | ok(List.empty[A]) named ("sepBy(" + p.toString + "," + s.toString + ")")
   }
 
-  def pairBy[Input, A, B](a: Parser[Input, A], delim: Parser[Input, _], b: Parser[Input, B]): Parser[Input, (A, B)] = 
+  def pairBy[Input, A, B](a: Parser[Input, A], delim: Parser[Input, _], b: Parser[Input, B]): Parser[Input, (A, B)] =
     (a <~ delim) ~ b
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
@@ -396,5 +380,5 @@ object Combinator {
 
   def count[Input, A](n: Int, p: Parser[Input, A]): Parser[Input, List[A]] =
     (1 to n).foldRight(ok[Input](List[A]()))((_, a) => cons(p, a).map(_.toList))
-  
+
 }

--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
@@ -23,11 +23,11 @@ object Parser {
 
   def parse[Input, Output](p: Parser[Input, Output], input: Chain[Input]): ParseResult[Input, Output] = {
     def kf(a: State[Input], b: List[String], c: String) = Eval.now[Internal.Result[Input, Output]](
-      Internal.Fail(a.copy(input = chainDrop(a.input, a.pos.value)), b, c)
+      Internal.Fail(a.copy(input = a.cursor), b, c)
     )
     def ks(a: State[Input], b: Output) = Eval.now[Internal.Result[Input, Output]](
       Internal.Done(
-        a.copy(input = chainDrop(a.input, a.pos.value)),
+        a.copy(input = a.cursor),
         b
       )
     )
@@ -37,11 +37,11 @@ object Parser {
 
   def parseOnly[Input, Output](p: Parser[Input, Output], input: Chain[Input]): ParseResult[Input, Output] = {
     def kf(a: State[Input], b: List[String], c: String) = Eval.now[Internal.Result[Input, Output]](
-      Internal.Fail(a.copy(input = chainDrop(a.input, a.pos.value)), b, c)
+      Internal.Fail(a.copy(input = a.cursor), b, c)
     )
     def ks(a: State[Input], b: Output) = Eval.now[Internal.Result[Input, Output]](
       Internal.Done(
-        a.copy(input = chainDrop(a.input, a.pos.value)),
+        a.copy(input = a.cursor),
         b
       )
     )
@@ -59,10 +59,10 @@ object Parser {
     case object NotComplete extends IsComplete
   }
   final case class Pos(value: Int) extends AnyVal
-  final case class State[Input](input: Chain[Input], pos: Pos, complete: IsComplete)
+  final case class State[Input](input: Chain[Input], cursor: Chain[Input], complete: IsComplete)
   object State {
     def apply[Input](input: Chain[Input], done: IsComplete): State[Input] = 
-      new State(input, Pos(0), done)
+      new State(input, input, done)
   }
   
   object Internal {

--- a/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
@@ -47,9 +47,22 @@ class CombinatorSpec extends Specification with ScalaCheck {
       Parser.parseOnly(p, Chain('a', 'b', 'c', 'd')) must_==(expected)
     }
 
+    "take partial" >> {
+      val p = Combinator.take[Char](4)
+      val r1 = Parser.parse(p, Chain('a', 'b'))
+      val r2 = r1.feedMany(Chain('c', 'd', 'e'))
+      r2 must_==(ParseResult.Done(Chain.one('e'), Chain.fromSeq('a' to 'd')))
+    }
+
     "take fail" >> {
       val p = Combinator.take[Char](3)
       val expected = ParseResult.Fail(Chain.empty[Char], Nil, "not enough input")
+      Parser.parseOnly(p, Chain('a', 'b')) must_==(expected)
+    }
+
+    "take orElse" >> {
+      val p = Combinator.take[Char](3) <+> Combinator.take[Char](1)
+      val expected = ParseResult.Done(Chain.one('b'), Chain.one('a'))
       Parser.parseOnly(p, Chain('a', 'b')) must_==(expected)
     }
 


### PR DESCRIPTION
This is a speculative change and I'm just throwing the idea out there.
Whether or not this should be pursued should probably be determined by
benchmarks (not yet implemented) and anticipated use-cases.

The idea behind this is that the current approach of keeping an index
into a Chain probably isn't very efficient. Chain isn't optimized for
index-based usage. Since parsers generally want to pull an element at a
time and inspect it, keeping track of a "cursor" into the current "tail"
of the Chain may be more natural/efficient.

One potential downside of this is that when more data is supplied via
feed/prompt, we have to concatenate the data to both the `input` and the
`cursor`. Depending on the extent to which we have shared structure
(including after we start popping more elements off of the cursor), this
may result in larger space requirements (up to 2x).

Sorry for all of the whitespace changes 😬I didn't realize how many I was making. If we want to pursue this change I can pull this into a separate commit if desired.