### PR TITLE
Cross-publish for Scala 2.11.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ stages:
 
 scala_version_213: &scala_version_213 "2.13.1"
 scala_version_212: &scala_version_212 "2.12.10"
+scala_version_212: &scala_version_211 "2.11.12"
 
 jobs:
   include:
@@ -24,6 +25,9 @@ jobs:
       script: sbt ++$TRAVIS_SCALA_VERSION test
     - name: test 2.12
       scala: *scala_version_212
+      script: sbt ++$TRAVIS_SCALA_VERSION test
+    - name: test 2.11
+      scala: *scala_version_211
       script: sbt ++$TRAVIS_SCALA_VERSION test
     - name: mima
       script: sbt +mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val site = project.in(file("site"))
 // General Settings
 lazy val commonSettings = Seq(
   scalaVersion := "2.13.1",
-  crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12"),
 
   addCompilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),


### PR DESCRIPTION
Would you have any objections to cross-publishing for Scala 2.11?
We use Databricks at work and unfortunately they seem to have no
interest in supporting Scala 2.12 even though Apache Spark has supported
it for over a year...