### PR TITLE
Switch from Chain to Queue, incorporate tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 val catsV = "2.0.0"
+
 val specs2V = "4.8.1"
 
 val kindProjectorV = "0.11.0"
@@ -34,7 +35,7 @@ lazy val site = project.in(file("site"))
       micrositeGithubOwner := "ChristopherDavenport",
       micrositeGithubRepo := "gato-parsec",
       micrositeBaseUrl := "/gato-parsec",
-      micrositeDocumentationUrl := "https://www.javadoc.io/doc/io.chrisdavenport/gato-parsec_2.12",
+      micrositeDocumentationUrl := "https://www.javadoc.io/doc/io.chrisdavenport/gato-parsec_2.13",
       micrositeGitterChannelUrl := "ChristopherDavenport/libraries", // Feel Free to Set To Something Else
       micrositeFooterText := None,
       micrositeHighlightTheme := "atom-one-light",

--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
@@ -55,7 +55,9 @@ object Parser {
     p(State.apply(input, IsComplete.Complete), kf, ks).value.translate
   }
 
-  private def fToQueue[F[_]: Foldable, A](fa: F[A]): Queue[A] = Queue(fa.toList:_*)
+  private def fToQueue[F[_]: Foldable, A](fa: F[A]): Queue[A] = {
+    fa.foldLeft(Queue.newBuilder[A])((builder, a) => builder.+=(a)).result()
+  }
 
   sealed trait IsComplete {
     def bool: Boolean = this match {

--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/implicits.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/implicits.scala
@@ -1,7 +1,6 @@
 package io.chrisdavenport.gatoparsec
 
-
-import cats.data.Chain
+import cats.Foldable
 
 object implicits {
   implicit class ParserOps[Input, A](private val p: Parser[Input, A]){
@@ -11,10 +10,11 @@ object implicits {
     def |[B >: A](p2: Parser[Input, B]): Parser[Input, B] = Combinator.orElse(p, p2)
     def ||[B](p2: Parser[Input, B]): Parser[Input, Either[A, B]] = Combinator.either(p, p2)
 
+    def collect[B](f: PartialFunction[A, B]): Parser[Input, B] = Combinator.collect(p, f)
     def filter(f: A => Boolean): Parser[Input, A] = Combinator.filter(p)(f)
     def named(s: String): Parser[Input, A] = Combinator.named(p, s)
 
-    def parseOnly(i: Chain[Input]) = Parser.parseOnly(p, i)
-    def parse(i: Chain[Input]) = Parser.parse(p, i)
+    def parseOnly[F[_]: Foldable](i: F[Input]) = Parser.parseOnly(p, i)
+    def parse[F[_]: Foldable](i: F[Input]) = Parser.parse(p, i)
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
@@ -74,7 +74,7 @@ class CombinatorSpec extends Specification with ScalaCheck {
       val p = Combinator.take[Char](4)
       val r1 = Parser.parse(p, Queue('a', 'b'))
       val r2 = r1.feedMany(Queue('c', 'd', 'e'))
-      r2 must_==(ParseResult.Done(Queue('e'), Queue.from('a' to 'd')))
+      r2 must_==(ParseResult.Done(Queue('e'), Queue('a' to 'd':_*)))
     }
 
     "take fail" in {


### PR DESCRIPTION
- Switch from Chain which is innefficient to Queue, which is very efficient at drop and take operations.
- Documentation Seems to imply this should work well for our use case. https://www.scala-lang.org/api/2.12.0/scala/collection/immutable/Queue.html