### PR TITLE
Add benchmarks and use cursor/uncons instead of pos/drop

### DIFF
--- a/bench/src/main/scala/io/chrisdavenport/gatoparsec/bench/ParserBench.scala
+++ b/bench/src/main/scala/io/chrisdavenport/gatoparsec/bench/ParserBench.scala
@@ -16,7 +16,7 @@ class ParserBench {
 
   @Benchmark
   def streamingSmallReadSmallChunks(): Unit = {
-    val data = Iterator.unfold(0)(i => if (i === 10000) None else Some((Chain('a', 'b'), i + 1)))
+    val data = (0 until 10000).map(_ => Chain('a', 'b'))
     val res = data.foldLeft(Parser.parse(many(aOrB), Chain.empty))((parseResult, input) =>
       parseResult.feedMany(input)
     )
@@ -30,7 +30,7 @@ class ParserBench {
   @Benchmark
   def streamingBigReadSmallChunksCount(): Unit = {
     val bigNum = 10000
-    val data = Iterator.unfold(0)(i => if (i === bigNum) None else Some((Chain('a','b'), i + 1)))
+    val data = (0 until bigNum).map(_ => Chain('a', 'b'))
     val p = count(bigNum * 2 - 1, elem[Char].void) ~> elem[Char]
     val res = data.foldLeft(Parser.parse(p, Chain.empty))((parseResult, input) =>
       parseResult.feedMany(input)
@@ -45,7 +45,7 @@ class ParserBench {
   @Benchmark
   def streamingBigReadSmallChunksTake(): Unit = {
     val bigNum = 10000
-    val data = Iterator.unfold(0)(i => if (i === bigNum) None else Some((Chain('a','b'), i + 1)))
+    val data = (0 until bigNum).map(_ => Chain('a', 'b'))
     val p = take[Char](bigNum * 2 - 1).void ~> elem[Char]
     val res = data.foldLeft(Parser.parse(p, Chain.empty))((parseResult, input) =>
       parseResult.feedMany(input)

--- a/bench/src/main/scala/io/chrisdavenport/gatoparsec/bench/ParserBench.scala
+++ b/bench/src/main/scala/io/chrisdavenport/gatoparsec/bench/ParserBench.scala
@@ -1,0 +1,59 @@
+package io.chrisdavenport.gatoparsec
+package bench
+
+import implicits._
+import Combinator._
+
+import cats.data.Chain
+import cats.implicits._
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class ParserBench {
+  val a = elem[Char].filter(_ === 'a')
+  val b = elem[Char].filter(_ === 'b')
+  val aOrB: Parser[Char, Char] = a | b
+
+  @Benchmark
+  def streamingSmallReadSmallChunks(): Unit = {
+    val data = Iterator.unfold(0)(i => if (i === 10000) None else Some((Chain('a', 'b'), i + 1)))
+    val res = data.foldLeft(Parser.parse(many(aOrB), Chain.empty))((parseResult, input) =>
+      parseResult.feedMany(input)
+    )
+    val isDone = res.feedMany(Chain.empty) match {
+      case ParseResult.Done(_, _) => true
+      case _ => false
+    }
+    assert(isDone)
+  }
+
+  @Benchmark
+  def streamingBigReadSmallChunksCount(): Unit = {
+    val bigNum = 10000
+    val data = Iterator.unfold(0)(i => if (i === bigNum) None else Some((Chain('a','b'), i + 1)))
+    val p = count(bigNum * 2 - 1, elem[Char].void) ~> elem[Char]
+    val res = data.foldLeft(Parser.parse(p, Chain.empty))((parseResult, input) =>
+      parseResult.feedMany(input)
+    )
+    val isDone = res match {
+      case ParseResult.Done(_, 'b') => true
+      case _ => false
+    }
+    assert(isDone)
+  }
+
+  @Benchmark
+  def streamingBigReadSmallChunksTake(): Unit = {
+    val bigNum = 10000
+    val data = Iterator.unfold(0)(i => if (i === bigNum) None else Some((Chain('a','b'), i + 1)))
+    val p = take[Char](bigNum * 2 - 1).void ~> elem[Char]
+    val res = data.foldLeft(Parser.parse(p, Chain.empty))((parseResult, input) =>
+      parseResult.feedMany(input)
+    )
+    val isDone = res match {
+      case ParseResult.Done(_, 'b') => true
+      case _ => false
+    }
+    assert(isDone)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,12 +10,22 @@ val betterMonadicForV = "0.3.1"
 lazy val `gato-parsec` = project.in(file("."))
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublishPlugin)
-  .aggregate(core, site)
+  .aggregate(core, bench, site)
 
 lazy val core = project.in(file("core"))
   .settings(commonSettings)
   .settings(
     name := "gato-parsec"
+  )
+
+lazy val bench = project.in(file("bench"))
+  .disablePlugins(MimaPlugin)
+  .enablePlugins(NoPublishPlugin)
+  .enablePlugins(JmhPlugin)
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    name := "gato-parsec-bench"
   )
 
 lazy val site = project.in(file("site"))

--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/Combinator.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/Combinator.scala
@@ -21,7 +21,7 @@ object Combinator {
   private class OkParser[Input, Output](a: Output) extends  Parser[Input, Output]{
     override def toString(): String = s"ok(${a.toString()})"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
@@ -29,18 +29,18 @@ object Combinator {
   }
 
   /** Parser that consumes no data and fails with the specified error message. */
-  def err[Input, Output](what: String): Parser[Input, Output] = 
+  def err[Input, Output](what: String): Parser[Input, Output] =
     new ErrParser[Input, Output](what)
   private class ErrParser[Input, Output](what: String) extends Parser[Input, Output]{
     override def toString(): String = s"err($what)"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
       Eval.defer(kf(st0, Nil, what))
   }
-  
+
   /** Construct the given parser lazily; useful when defining recursive parsers. */
   def delay[Input, Output](p: => Parser[Input, Output]): Parser[Input, Output] =
     new DelayParser[Input, Output](p)
@@ -48,27 +48,15 @@ object Combinator {
   private class DelayParser[Input, Output](p: => Parser[Input,Output]) extends Parser[Input, Output]{
     override def toString(): String = p.toString
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Output) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
       p.apply(st0, kf, ks)
   }
 
-  
-  /////
 
-  def advance[Input](n: Int): Parser[Input, Unit] = 
-    new AdvanceParser[Input, Unit](n)
-  private class AdvanceParser[Input, Output](n: Int) extends Parser[Input, Unit]{
-    override def toString(): String = s"advance($n)"
-    def apply[R](
-      st0: State[Input], 
-      kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
-      ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
-    ): Eval[Internal.Result[Input, R]] =
-      ks(st0.copy(pos = Parser.Pos(st0.pos.value + n)), ())
-  }
+  /////
 
   private def prompt[Input, Output](
     st0: State[Input],
@@ -76,8 +64,8 @@ object Combinator {
     ks: State[Input] => Eval[Internal.Result[Input, Output]]
   ): Parser.Internal.Result[Input, Output] =
     Parser.Internal.Partial[Input, Output](s =>
-    if (s.isEmpty) Eval.defer(kf(st0.copy(complete =IsComplete.Complete)))
-    else Eval.defer(ks(st0.copy(input = st0.input <+> s, complete = IsComplete.NotComplete)))
+    if (s.isEmpty) Eval.defer(kf(st0.copy(complete = IsComplete.Complete)))
+    else Eval.defer(ks(State(input = st0.input <+> s, cursor = st0.cursor <+> s, complete = IsComplete.NotComplete)))
   )
 
   def demandInput[Input]: Parser[Input, Unit] = new DemandInputParser[Input]
@@ -85,7 +73,7 @@ object Combinator {
   private class DemandInputParser[Input] extends Parser[Input, Unit]{
     override def toString = "demandInput"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
@@ -98,47 +86,16 @@ object Combinator {
       )
   }
 
-  def ensureSuspended[Input](n: Int): Parser[Input, Chain[Input]] =
-    new EnsureSuspendedParser[Input](n)
-  private class EnsureSuspendedParser[Input](n: Int) extends Parser[Input, Chain[Input]]{
-    override def toString(): String = s"ensureSuspended($n)"
-    def apply[R](
-      st0: Parser.State[Input],
-      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
-      ks: (Parser.State[Input], Chain[Input]) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + n)
-        // Can Do Better - Chain Methods Inadequate
-        Eval.defer(ks(st0, Chain.fromSeq(st0.input.toList.drop(st0.pos.value).take(n))))
-      else 
-        Eval.defer(ensureSuspended(n)(st0, kf, ks))
-  }
-
-  def ensure[Input](n: Int): Parser[Input, Chain[Input]] =
-    new EnsureParser[Input](n)
-  private class EnsureParser[Input](n: Int) extends Parser[Input, Chain[Input]]{
-    override def toString(): String = s"ensure($n)"
-    def apply[R](
-      st0: Parser.State[Input],
-      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
-      ks: (Parser.State[Input], Chain[Input]) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + n)
-        Eval.defer(ks(st0, Chain.fromSeq(st0.input.toList.drop(st0.pos.value).take(n))))
-      else
-        Eval.defer(ensureSuspended(n)(st0, kf, ks))
-  }
-
   def wantInput[Input]: Parser[Input, Boolean] =
-    new WantInputParser[Input] 
+    new WantInputParser[Input]
   private class WantInputParser[Input] extends  Parser[Input, Boolean]{
     override def toString = "wantInput"
     def apply[R](
       st0: Parser.State[Input],
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], Boolean) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
-      if (st0.input.length >= st0.pos.value + 1) Eval.defer(ks(st0, true))
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      if (st0.cursor.nonEmpty) Eval.defer(ks(st0, true))
       else if (st0.complete.bool) Eval.defer(ks(st0, false))
       else Eval.now(prompt(st0, a => ks(a, false), a => ks(a, true)))
   }
@@ -146,41 +103,41 @@ object Combinator {
   /////
 
   /** Parser that produces the remaining input (but does not consume it). */
-  def get[Input]: Parser[Input, Chain[Input]] = 
+  def get[Input]: Parser[Input, Chain[Input]] =
     new GetParser[Input]
   private class GetParser[Input] extends Parser[Input, Chain[Input]]{
     override def toString = "get"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Chain[Input]) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, Parser.chainDrop(st0.input, st0.pos.value)))
+      Eval.defer(ks(st0, st0.cursor))
   }
 
   /* Parser that produces the current offset in the input. */
-  def pos[Input]: Parser[Input, Int] = 
+  def cursor[Input]: Parser[Input, Chain[Input]] =
     new PosParser[Input]
-  private class PosParser[Input] extends Parser[Input, Int]{
+  private class PosParser[Input] extends Parser[Input, Chain[Input]]{
     override def toString = "pos"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
-      ks: (State[Input], Int) => Eval[Internal.Result[Input, R]]
+      ks: (State[Input], Chain[Input]) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, st0.pos.value))
+      Eval.defer(ks(st0, st0.cursor))
   }
-  
+
   def endOfChunk[Input]: Parser[Input, Boolean] =
     new EndOfChunkParser[Input]
   private class EndOfChunkParser[Input] extends Parser[Input, Boolean]{
     override def toString = "endOfChunk"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Boolean) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] =
-      Eval.defer(ks(st0, st0.pos.value == st0.input.length))
+      Eval.defer(ks(st0, st0.cursor.isEmpty))
   }
 
   def endOfInput[Input]: Parser[Input, Unit] =
@@ -188,11 +145,11 @@ object Combinator {
   private class EndOfInputParser[Input] extends Parser[Input, Unit]{
     override def toString = "endOfInput"
     def apply[R](
-      st0: State[Input], 
+      st0: State[Input],
       kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
       ks: (State[Input], Unit) => Eval[Internal.Result[Input, R]]
     ): Eval[Internal.Result[Input, R]] = Eval.defer{
-      if (st0.pos.value >= st0.input.length) {
+      if (st0.cursor.isEmpty) {
         if (st0.complete.bool) ks(st0, ())
         else demandInput(
           st0,
@@ -205,8 +162,8 @@ object Combinator {
     }
   }
 
-  
-  def discardLeft[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] = 
+
+  def discardLeft[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] =
     new DiscardLeftParser[Input,A, B](m, b)
   private class DiscardLeftParser[Input, A, B](
     m: Parser[Input, A],
@@ -214,7 +171,7 @@ object Combinator {
   ) extends Parser[Input, B]{
     override def toString(): String = s"($m) ~> $b"
     def apply[R](
-        st0: State[Input], 
+        st0: State[Input],
         kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
         ks: (State[Input], B) => Eval[Internal.Result[Input, R]]
       ): Eval[Internal.Result[Input, R]] = {
@@ -224,20 +181,20 @@ object Combinator {
       }
   }
 
-  def discardRight[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]): Parser[Input, A] = 
+  def discardRight[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]): Parser[Input, A] =
     new DiscardRightParser(m, b)
   private class DiscardRightParser[Input, A, B](m: Parser[Input, A], b: Parser[Input, B]) extends Parser[Input, A]{
     override def toString(): String = s"($m) <~ $b"
     def apply[R](
-        st0: State[Input], 
+        st0: State[Input],
         kf: (State[Input], List[String], String) => Eval[Internal.Result[Input, R]],
         ks: (State[Input], A) => Eval[Internal.Result[Input, R]]
       ): Eval[Internal.Result[Input, R]] = {
         Eval.defer(
           m(
             st0,
-            kf, 
-            (st1: State[Input], a: A) => 
+            kf,
+            (st1: State[Input], a: A) =>
               b(st1, kf, (st2: State[Input], _: B) => ks(st2, a)
             )
           )
@@ -260,7 +217,7 @@ object Combinator {
   }
 
 
-  def orElse[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] = 
+  def orElse[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, B] =
     new OrElseParser(m, b)
   private class OrElseParser[Input, A, B >: A](m: Parser[Input, A], b: => Parser[Input, B]) extends Parser[Input, B]{
     override def toString(): String = s"($m) | $b"
@@ -269,12 +226,12 @@ object Combinator {
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], B) => Eval[Parser.Internal.Result[Input,R]]
     ): Eval[Parser.Internal.Result[Input,R]] = Eval.defer(
-      m(st0, (st1: State[Input], _: List[String], _: String) => b(st1.copy(pos = st0.pos), kf, ks), ks)
+      m(st0, (st1: State[Input], _: List[String], _: String) => b(st1.copy(cursor = st0.cursor), kf, ks), ks)
     )
   }
 
 
-  def either[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, Either[A, B]] = 
+  def either[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]): Parser[Input, Either[A, B]] =
     new EitherParser[Input, A, B](m, b)
   private class EitherParser[Input, A, B](m: Parser[Input, A], b: => Parser[Input, B]) extends Parser[Input, Either[A, B]]{
     override def toString(): String = s"($m) || $b"
@@ -284,14 +241,42 @@ object Combinator {
       ks: (Parser.State[Input], Either[A, B]) => Eval[Parser.Internal.Result[Input,R]]
     ): Eval[Parser.Internal.Result[Input,R]] = Eval.defer(m(
       st0,
-      (st1: State[Input], _: List[String], _: String) => 
-        b(st1.copy(pos= st0.pos), kf, (st1: State[Input], b: B) => ks(st1, Right(b))),
+      (st1: State[Input], _: List[String], _: String) =>
+        b(st1.copy(cursor = st0.cursor), kf, (st1: State[Input], b: B) => ks(st1, Right(b))),
       (st1: State[Input], a: A) => ks(st1, Left(a))
     ))
   }
 
+  def elemSuspended[Input]: Parser[Input, Input] = new ElemSuspendedParser[Input]
+  private class ElemSuspendedParser[Input] extends Parser[Input, Input]{
+    override def toString(): String = "elemSuspended"
+    def apply[R](
+      st0: Parser.State[Input],
+      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
+      ks: (Parser.State[Input], Input) => Eval[Parser.Internal.Result[Input,R]]
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      st0.cursor.uncons match {
+        case Some((h, t)) => Eval.defer(ks(st0.copy(cursor = t), h))
+        case None => Eval.defer(discardLeft(demandInput[Input], elemSuspended[Input])(st0, kf, ks))
+      }
+  }
 
-  def named[Input, A](m: Parser[Input, A], s: => String): Parser[Input, A] = 
+  def elem[Input]: Parser[Input, Input] = new ElemParser[Input]
+  private class ElemParser[Input] extends Parser[Input, Input]{
+    override def toString(): String = "elem"
+    def apply[R](
+      st0: Parser.State[Input],
+      kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
+      ks: (Parser.State[Input], Input) => Eval[Parser.Internal.Result[Input,R]]
+    ): Eval[Parser.Internal.Result[Input,R]] =
+      st0.cursor.uncons match {
+        case Some((h, t)) => Eval.defer(ks(st0.copy(cursor = t), h))
+        case None => Eval.defer(elemSuspended(st0, kf, ks))
+      }
+  }
+
+
+  def named[Input, A](m: Parser[Input, A], s: => String): Parser[Input, A] =
     new NamedParser(m, s)
   private class NamedParser[Input, A](m: Parser[Input, A], s: => String) extends Parser[Input, A]{
     override def toString = s
@@ -299,7 +284,7 @@ object Combinator {
       st0: Parser.State[Input],
       kf: (Parser.State[Input], List[String], String) => Eval[Parser.Internal.Result[Input,R]],
       ks: (Parser.State[Input], A) => Eval[Parser.Internal.Result[Input,R]]
-    ): Eval[Parser.Internal.Result[Input,R]] = 
+    ): Eval[Parser.Internal.Result[Input,R]] =
       Eval.defer(m(st0, (st1: State[Input], stack: List[String], msg: String) => kf(st1, s:: stack, msg), ks))
   }
 
@@ -317,30 +302,29 @@ object Combinator {
   }
 
 
-  def modifyName[Input, A](m: Parser[Input, A], f: String => String): Parser[Input, A] = 
+  def modifyName[Input, A](m: Parser[Input, A], f: String => String): Parser[Input, A] =
     named(m, f(m.toString()))
 
   // Higher Level Combinators
   // Allowed to Use Implicits Based on the above
   import io.chrisdavenport.gatoparsec.implicits._
 
-  def take[Input](n: Int): Parser[Input, Chain[Input]] = 
-    ensure[Input](n).flatMap{c => 
-      advance(n) ~> ok(c)
-    }
+  // this could probably be better optimized
+  def take[Input](n: Int): Parser[Input, Chain[Input]] =
+    Traverse[Chain].sequence(Chain.fromSeq(List.fill(n)(elem[Input])))
 
-  def filter[Input, A](m: Parser[Input, A])(p: A => Boolean): Parser[Input, A] = 
-    m.flatMap{a => 
+  def filter[Input, A](m: Parser[Input, A])(p: A => Boolean): Parser[Input, A] =
+    m.flatMap{a =>
       if (p(a)) ok[Input](a) else err[Input, A]("filter")
     } named "filter(...)"
-  
-  def collect[Input, A, B](m: Parser[Input, A], f: PartialFunction[A, B]): Parser[Input, B] = 
+
+  def collect[Input, A, B](m: Parser[Input, A], f: PartialFunction[A, B]): Parser[Input, B] =
     filter(m)(f isDefinedAt _).map(f)
 
-  def cons[Input, A, B >: A](m: Parser[Input, A], n: => Parser[Input, List[B]]): Parser[Input, NonEmptyList[B]] = 
+  def cons[Input, A, B >: A](m: Parser[Input, A], n: => Parser[Input, List[B]]): Parser[Input, NonEmptyList[B]] =
     m.flatMap{x => n.map(xs => NonEmptyList(x, xs))}
 
-  def phrase[Input, A](p: Parser[Input, A]): Parser[Input, A] = 
+  def phrase[Input, A](p: Parser[Input, A]): Parser[Input, A] =
     p <~ endOfInput named ("phrase" + p.toString())
 
   def many[Input, A](p: => Parser[Input, A]): Parser[Input, List[A]] = {
@@ -351,7 +335,7 @@ object Combinator {
   def many1[Input, A](p: Parser[Input, A]): Parser[Input, NonEmptyList[A]] =
     cons(p, many(p))
 
-  def manyN[Input, A](n: Int, a: Parser[Input, A]): Parser[Input, List[A]] = 
+  def manyN[Input, A](n: Int, a: Parser[Input, A]): Parser[Input, List[A]] =
     (1.to(n)).foldRight(ok[Input](List[A]()))((_, p) => cons(a, p).map(_.toList))
       .named("ManyN(" + n.toString + ", " + a.toString + ")")
 
@@ -360,19 +344,19 @@ object Combinator {
     scan named "manyUntil(" + p.toString() + "," + q.toString() + ")"
   }
 
-  def skipMany[Input](p: Parser[Input, _]): Parser[Input, Unit] = 
+  def skipMany[Input](p: Parser[Input, _]): Parser[Input, Unit] =
     many(p).map(_ => ()) named s"skipMany($p)"
-  
-  def skipMany1[Input](p: Parser[Input, _]): Parser[Input, Unit] = 
+
+  def skipMany1[Input](p: Parser[Input, _]): Parser[Input, Unit] =
     many1(p).map(_ => ()) named s"skipMany1($p)"
-  
+
   def skipManyN[Input](n: Int, p: Parser[Input, _]): Parser[Input, Unit] =
     manyN(n, p).map(_ => ()) named s"skipManyN($n,$p)"
 
   def sepBy1[Input, A](p: Parser[Input, A], s: Parser[Input, _]): Parser[Input, NonEmptyList[A]] = {
-    lazy val scan : Parser[Input, NonEmptyList[A]] = 
+    lazy val scan : Parser[Input, NonEmptyList[A]] =
       cons(p, s ~> scan.map(_.toList) | ok(Nil))
-    
+
     scan named s"sepBy1($p,$s)"
   }
 
@@ -380,7 +364,7 @@ object Combinator {
     cons(p, ((s ~> sepBy1(p,s)).map(_.toList) | ok(List.empty[A]))).map(_.toList) | ok(List.empty[A]) named ("sepBy(" + p.toString + "," + s.toString + ")")
   }
 
-  def pairBy[Input, A, B](a: Parser[Input, A], delim: Parser[Input, _], b: Parser[Input, B]): Parser[Input, (A, B)] = 
+  def pairBy[Input, A, B](a: Parser[Input, A], delim: Parser[Input, _], b: Parser[Input, B]): Parser[Input, (A, B)] =
     (a <~ delim) ~ b
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
@@ -396,5 +380,5 @@ object Combinator {
 
   def count[Input, A](n: Int, p: Parser[Input, A]): Parser[Input, List[A]] =
     (1 to n).foldRight(ok[Input](List[A]()))((_, a) => cons(p, a).map(_.toList))
-  
+
 }

--- a/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
+++ b/core/src/main/scala/io/chrisdavenport/gatoparsec/Parser.scala
@@ -23,11 +23,11 @@ object Parser {
 
   def parse[Input, Output](p: Parser[Input, Output], input: Chain[Input]): ParseResult[Input, Output] = {
     def kf(a: State[Input], b: List[String], c: String) = Eval.now[Internal.Result[Input, Output]](
-      Internal.Fail(a.copy(input = chainDrop(a.input, a.pos.value)), b, c)
+      Internal.Fail(a.copy(input = a.cursor), b, c)
     )
     def ks(a: State[Input], b: Output) = Eval.now[Internal.Result[Input, Output]](
       Internal.Done(
-        a.copy(input = chainDrop(a.input, a.pos.value)),
+        a.copy(input = a.cursor),
         b
       )
     )
@@ -37,11 +37,11 @@ object Parser {
 
   def parseOnly[Input, Output](p: Parser[Input, Output], input: Chain[Input]): ParseResult[Input, Output] = {
     def kf(a: State[Input], b: List[String], c: String) = Eval.now[Internal.Result[Input, Output]](
-      Internal.Fail(a.copy(input = chainDrop(a.input, a.pos.value)), b, c)
+      Internal.Fail(a.copy(input = a.cursor), b, c)
     )
     def ks(a: State[Input], b: Output) = Eval.now[Internal.Result[Input, Output]](
       Internal.Done(
-        a.copy(input = chainDrop(a.input, a.pos.value)),
+        a.copy(input = a.cursor),
         b
       )
     )
@@ -59,10 +59,10 @@ object Parser {
     case object NotComplete extends IsComplete
   }
   final case class Pos(value: Int) extends AnyVal
-  final case class State[Input](input: Chain[Input], pos: Pos, complete: IsComplete)
+  final case class State[Input](input: Chain[Input], cursor: Chain[Input], complete: IsComplete)
   object State {
     def apply[Input](input: Chain[Input], done: IsComplete): State[Input] = 
-      new State(input, Pos(0), done)
+      new State(input, input, done)
   }
   
   object Internal {

--- a/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/gatoparsec/CombinatorSpec.scala
@@ -47,9 +47,22 @@ class CombinatorSpec extends Specification with ScalaCheck {
       Parser.parseOnly(p, Chain('a', 'b', 'c', 'd')) must_==(expected)
     }
 
+    "take partial" >> {
+      val p = Combinator.take[Char](4)
+      val r1 = Parser.parse(p, Chain('a', 'b'))
+      val r2 = r1.feedMany(Chain('c', 'd', 'e'))
+      r2 must_==(ParseResult.Done(Chain.one('e'), Chain.fromSeq('a' to 'd')))
+    }
+
     "take fail" >> {
       val p = Combinator.take[Char](3)
       val expected = ParseResult.Fail(Chain.empty[Char], Nil, "not enough input")
+      Parser.parseOnly(p, Chain('a', 'b')) must_==(expected)
+    }
+
+    "take orElse" >> {
+      val p = Combinator.take[Char](3) <+> Combinator.take[Char](1)
+      val expected = ParseResult.Done(Chain.one('b'), Chain.one('a'))
       Parser.parseOnly(p, Chain('a', 'b')) must_==(expected)
     }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")
 
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.0.2")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.0.3")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -15,3 +15,9 @@ libraryDependencies ++= Seq(
   "io.chrisdavenport" %% "gato-parsec" % "<version>"
 )
 ```
+
+## Performance
+
+At this point, gato-parsec is an experimental library. While [some effort](https://github.com/ChristopherDavenport/gato-parsec/pull/5) has been put into making it reasonably performant, if performance is really critical to your application, gato-parsec in its current form might not be the library for you.
+
+Be aware that in the worst case, gen-parsec could have a memory requirement on par with *2x* the size of the input data. In practice, [structural sharing](https://en.wikipedia.org/wiki/Persistent_data_structure) should usually result in significantly lower actual memory usage.


### PR DESCRIPTION
See related discussion in #1 (which this replaces) and #3.

This adds a few benchmarks that attempt to simulate a few different use-cases:

* `streamingBigReadSmallChunksCount` feeds a bunch of small chunks of data into a parser that is looking for a large chunk of data at a time by using `count` with a large `n`.
* `streamingBigReadSmallChunksTake` is similar to `streamingBigReadSmallChunksCount` but uses `take` instead of `count`.
* `streamingSmallReadSmallChunks` feeds a bunch of small chunks of data into a parser that is looking for small chunks of data at a time.

## disclaimers

1. I don't know how well these scenarios line up with real-world use-cases. I tried to pick some cases that seemed like they could hit performance bottlenecks but that weren't too far from scenarios that I might expect to pop up in the wild.
2. This is a very small set of benchmarks. Ideally many more cases would be tested. For example, I haven't done any benches where we are feeding large chunks of data at a time. I was starting to lose steam writing benchmarks and wanted to get something out there for review.
3. Benchmarks don't tell the real story yada yada yada

## results

The are throughput measurements, so bigger numbers are better. In these particular examples, the cursor/uncons approach with Chain seems to have orders of magnitude better performance than the other two approaches.

My speculation about why the other two approaches have such low throughput would be that it relates to the repeated size checks, indexing into, and dropping elements from the front of these structures. With the cursor-based approach, we only have to go back and start at the beginning of `input` if we need to backtrack for an `orElse`. With the `pos`-based approach, we are constantly taking the original `input` and dropping elements (probably an `O(pos)` operation) to get to the relevant position in the structure. When we move on to the next parser in the chain, we have to do this again (with a slightly higher `pos`). The `length` check on this structures is likely even worse, as it is generally `O(input.length)`. I tried using `lengthCompare` instead of `length` in the `pos`-based implementations, but I didn't see a significant improvement.

## raw data

### current master (chain with pos/drop)

[code](https://github.com/ceedubs/gato-parsec/tree/d33eafbe3e3cf090ee264937784c4ece9240fff4)

```
[info] Benchmark                                      Mode  Cnt  Score   Error  Units                 
[info] ParserBench.streamingBigReadSmallChunksCount  thrpt   10  0.061 ± 0.001  ops/s                 
[info] ParserBench.streamingSmallReadSmallChunks     thrpt   10  0.046 ± 0.003  ops/s
[info] ParserBench.streamingBigReadSmallChunksTake   thrpt   10  0.509 ± 0.008  ops/s
```

### Queue with pos/drop
[code](https://github.com/ceedubs/gato-parsec/tree/65e25bc519fa19d9c3ce5c37769108ae02f67236)

```
[info] Benchmark                                      Mode  Cnt  Score   Error  Units
[info] ParserBench.streamingBigReadSmallChunksCount  thrpt   10  0.258 ± 0.004  ops/s
[info] ParserBench.streamingBigReadSmallChunksTake   thrpt   10  1.362 ± 0.028  ops/s
[info] ParserBench.streamingSmallReadSmallChunks     thrpt   10  0.195 ± 0.007  ops/s
```

### chain with cursor/uncons

[code](https://github.com/ceedubs/gato-parsec/tree/7c2d5500abfa965eb71e710c69033e12f9996b28)

```
[info] Benchmark                                      Mode  Cnt    Score    Error  Units
[info] ParserBench.streamingBigReadSmallChunksCount  thrpt   10  192.938 ±  8.650  ops/s
[info] ParserBench.streamingBigReadSmallChunksTake   thrpt   10  204.053 ± 11.377  ops/s
[info] ParserBench.streamingSmallReadSmallChunks     thrpt   10  145.526 ±  7.355  ops/s
```